### PR TITLE
Revert "Fix resolving urls in request service"

### DIFF
--- a/src/service/GlobalService.ts
+++ b/src/service/GlobalService.ts
@@ -14,7 +14,7 @@ export class GlobalService {
      * @param delayDistribution Delay definition
      */
     async updateGlobalSettings(delayDefinition: DelayDefinition): Promise<void> {
-        return HttpUtil.fetch(resolve(`${this.baseUri}/`, 'settings'), {
+        return HttpUtil.fetch(resolve(this.baseUri, 'settings'), {
             method: 'POST',
             body: JSON.stringify(delayDefinition)
         });
@@ -24,13 +24,13 @@ export class GlobalService {
      * Reset mappings to the default set and reset the request journal
      */
     async resetAll(): Promise<void> {
-        return HttpUtil.fetch(resolve(`${this.baseUri}/`, 'reset'), { method: 'POST' });
+        return HttpUtil.fetch(resolve(this.baseUri, 'reset'), { method: 'POST' });
     }
 
     /**
     * Shut down the WireMock server
     */
     async shutdown(): Promise<void> {
-        return HttpUtil.fetch(resolve(`${this.baseUri}/`, 'shutdown'), { method: 'POST' });
+        return HttpUtil.fetch(resolve(this.baseUri, 'shutdown'), { method: 'POST' });
     }
 }


### PR DESCRIPTION
Hi,

while using your module, I encountered and error and was not able to actually connect to the wiremock standalone server :
```
[de5f1c38-8257-474c-b4bb-65c8bbe858c4] Request: [POST] http://localhost:8080/__admin//reset
[de5f1c38-8257-474c-b4bb-65c8bbe858c4] Response: [404] Not Found
(node:200) UnhandledPromiseRejectionWarning: Error: Response: [404] Not Found
    at Function.<anonymous> (/app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:49:23)
    at Generator.next (<anonymous>)
    at /app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:4:12)
    at Function.parseResponse (/app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:45:16)
    at Function.<anonymous> (/app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:36:29)
    at Generator.next (<anonymous>)
    at fulfilled (/app/src/node_modules/wiremock-rest-client/dist/util/HttpUtil.js:5:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

Removing the extra '/' seems to do the trick and work as expected.

FYI, I'm using wiremock-2.26.3, through this docker image:
https://hub.docker.com/r/rodolpheche/wiremock/