### PR TITLE
feat: add scenario state methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 The WireMock REST client is a lightweight module to interact with a running [WireMock](http://wiremock.org) server based on the [OpenAPI 3.0 spec](http://wiremock.org/docs/api/) via REST.
 
 <!-- TOC -->
-- [Installation](#installation)
-- [Usage](#usage)
-- [API](#api)
+- [WireMock REST Client](#wiremock-rest-client)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [API](#api)
     - [Global](#global)
     - [Stub mappings](#stub-mappings)
     - [Recordings](#recordings)
     - [Requests](#requests)
     - [Scenarios](#scenarios)
-- [Configuration](#configuration)
+  - [Configuration](#configuration)
     - [Proxy](#proxy)
+    - [Headers](#headers)
     - [Log level](#log-level)
     - [Continue on failure](#continue-on-failure)
-- [CLI](#cli)
+  - [CLI](#cli)
 <!-- /TOC -->
 
 ## Installation
@@ -131,6 +133,8 @@ const requests = await wireMockRestClient.requests.getAllRequests();
 ### Scenarios
 - `getAllScenarios(): Promise<Scenario[]>`
 - `resetAllScenarios(): Promise<void>`
+- `resetScenario(scenarioId: string): Promise<void>`
+- `setScenarioState(scenarioId: string, state: string): Promise<void>`
 
 Example:
 ```js

--- a/src/service/scenario.service.ts
+++ b/src/service/scenario.service.ts
@@ -27,7 +27,7 @@ export class ScenarioService {
      * Reset the state of a single scenario
      */
     async resetScenario(scenarioId: string): Promise<void> {
-        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'reset'), { method: 'POST' });
+        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'state'), { method: 'PUT' });
     }
 
     /**

--- a/src/service/scenario.service.ts
+++ b/src/service/scenario.service.ts
@@ -17,9 +17,26 @@ export class ScenarioService {
     }
 
     /**
-    * Reset the state of all scenarios
-    */
+     * Reset the state of all scenarios
+     */
     async resetAllScenarios(): Promise<void> {
         return HttpUtil.fetch(resolve(`${this.baseUri}/`, 'reset'), { method: 'POST' });
+    }
+
+    /**
+     * Reset the state of a single scenario
+     */
+    async resetScenario(scenarioId: string): Promise<void> {
+        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'reset'), { method: 'POST' });
+    }
+
+    /**
+     * Set the state of a single scenario
+     */
+    async setScenarioState(scenarioId: string, state: string): Promise<void> {
+        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'state'), {
+            method: 'PUT',
+            body: JSON.stringify({ state }),
+        });
     }
 }

--- a/src/service/scenario.service.ts
+++ b/src/service/scenario.service.ts
@@ -27,7 +27,9 @@ export class ScenarioService {
      * Reset the state of a single scenario
      */
     async resetScenario(scenarioId: string): Promise<void> {
-        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'state'), { method: 'PUT' });
+        return HttpUtil.fetch(resolve(`${this.baseUri}/${scenarioId}/`, 'state'), {
+            method: 'PUT'
+        });
     }
 
     /**


### PR DESCRIPTION
# Description

Following the [Stateful Behaviour](https://wiremock.org/docs/stateful-behaviour/) guide, there are some missing method in the scenario service:

- Reset a single scenario

> The do the equivalent via the HTTP API, send an empty PUT to /__admin/scenarios/my_scenario/state.

- Set the state of a scenario

> PUT /__admin/scenarios/my_scenario/state
{
    "state": "state_2"
}